### PR TITLE
Update SentryClient+Live.swift

### DIFF
--- a/Sources/swift-log-sentry/SentryClient+Live.swift
+++ b/Sources/swift-log-sentry/SentryClient+Live.swift
@@ -2,6 +2,6 @@ import Sentry
 
 extension SentryClient {
   public static let live = SentryClient { crumb in
-    SentrySDK.addBreadcrumb(crumb: crumb)
+    SentrySDK.addBreadcrumb(crumb)
   }
 }


### PR DESCRIPTION
Fix for extraneous argument label 'crumb:' in call